### PR TITLE
DDO-398 Add prometheus values only to dev values for terra-cluster

### DIFF
--- a/terra/dev/values.yaml
+++ b/terra/dev/values.yaml
@@ -1,0 +1,52 @@
+terra-prometheus:
+  # TLS Values
+  vaultCert:
+    enabled: true
+    cert:
+      path: secret/dsde/firecloud/dev/common/server.crt
+      secretKey: value
+    key:
+      path: secret/dsde/firecloud/dev/common/server.key
+      secretKey: value
+    chain:
+      path: secret/common/ca-bundle.crt
+      secretKey: chain
+  prometheus-operator:
+    fullnameOverride: "terra-prometheus-operator"
+    prometheusOperator:
+      createCustomResource: false
+    prometheus:
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.global-static-ip-name: terra-dev-prometheus-ip
+          kubernetes.io/ingress.allow-http: "false"
+        hosts:
+          - "prometheus.dsde-dev.broadinstitute.org"
+        paths:
+          - /*
+        tls:
+          - secretName: terra-prometheus-cert
+      service:
+        annotations:
+          cloud.google.com/backend-config: '{"ports": {"9090": "prometheus-cloud-armor"}}'
+        type: NodePort
+      prometheusSpec:
+        externalUrl: https://prometheus.dsde-dev.broadinstitute.org
+        containers:
+          - name: stackdriver-exporter
+            image: gcr.io/stackdriver-prometheus/stackdriver-prometheus-sidecar:0.7.5
+            imagePullPolicy: Always
+            args:
+              - --stackdriver.project-id=broad-dsde-dev
+              - --prometheus.wal-directory=prometheus/wal
+              - --stackdriver.kubernetes.location=us-central1-a
+              - --stackdriver.kubernetes.cluster-name=terra-dev
+              #- \"--stackdriver.generic.location=us-central1\"
+              #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
+            ports:
+              - name: stackdriver-exp
+                containerPort: 9091
+            volumeMounts:
+              - name: prometheus-terra-prometheus-operator-prometheus-db
+                mountPath: /prometheus


### PR DESCRIPTION
This pr provides the environment specific overrides to deploy prometheus via the terra cluster chart for just the dev cluster. This is for testing the deployment of prometheus and associated resources via argocd.