### PR TITLE
DDO-398 prometheus argocd

### DIFF
--- a/terra/alpha/values.yaml
+++ b/terra/alpha/values.yaml
@@ -1,2 +1,54 @@
 terra-cluster-networking:
   enabled: false
+terra-prometheus:
+  # TLS Values
+  vaultCert:
+    enabled: true
+    cert:
+      path: secret/dsde/firecloud/alpha/common/server.crt
+      secretKey: value
+    key:
+      path: secret/dsde/firecloud/alpha/common/server.key
+      secretKey: value
+    chain:
+      path: secret/common/ca-bundle.crt
+      secretKey: chain
+  prometheus-operator:
+    fullnameOverride: "terra-prometheus-operator"
+    prometheusOperator:
+      createCustomResource: false
+    prometheus:
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.global-static-ip-name: terra-alpha-prometheus-ip
+          kubernetes.io/ingress.allow-http: "false"
+        hosts:
+          - "prometheus.dsde-alpha.broadinstitute.org"
+        paths:
+          - /*
+        tls:
+          - secretName: terra-prometheus-cert
+      service:
+        annotations:
+          cloud.google.com/backend-config: '{"ports": {"9090": "prometheus-cloud-armor"}}'
+        type: NodePort
+      prometheusSpec:
+        externalUrl: https://prometheus.dsde-alpha.broadinstitute.org
+        containers:
+          - name: stackdriver-exporter
+            image: gcr.io/stackdriver-prometheus/stackdriver-prometheus-sidecar:0.7.5
+            imagePullPolicy: Always
+            args:
+              - --stackdriver.project-id=broad-dsde-alpha
+              - --prometheus.wal-directory=prometheus/wal
+              - --stackdriver.kubernetes.location=us-central1-a
+              - --stackdriver.kubernetes.cluster-name=terra-alpha
+              #- \"--stackdriver.generic.location=us-central1\"
+              #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
+            ports:
+              - name: stackdriver-exp
+                containerPort: 9091
+            volumeMounts:
+              - name: prometheus-terra-prometheus-operator-prometheus-db
+                mountPath: /prometheus

--- a/terra/integration/values.yaml
+++ b/terra/integration/values.yaml
@@ -14,10 +14,10 @@ terra-prometheus:
       ingress:
         enabled: true
         annotations:
-          kubernetes.io/ingress.global-static-ip-name: terra-staging-prometheus-ip
+          kubernetes.io/ingress.global-static-ip-name: terra-integ-prometheus-ip
           kubernetes.io/ingress.allow-http: "false"
         hosts:
-          - "prometheus.dsde-staging.broadinstitute.org"
+          - "prometheus.integ.envs.broadinstitute.org"
         paths:
           - /*
         tls:

--- a/terra/integration/values.yaml
+++ b/terra/integration/values.yaml
@@ -1,3 +1,47 @@
 terra-cluster-networking:
   gateway:
     name: template-gateway
+terra-prometheus:
+  certmanager:
+    enabled: true
+    dnsNames: 
+      - "prometheus.integ.envs.broadinstitute.org"
+  prometheus-operator:
+    fullnameOverride: "terra-prometheus-operator"
+    prometheusOperator:
+      createCustomResource: false
+    prometheus:
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.global-static-ip-name: terra-staging-prometheus-ip
+          kubernetes.io/ingress.allow-http: "false"
+        hosts:
+          - "prometheus.dsde-staging.broadinstitute.org"
+        paths:
+          - /*
+        tls:
+          - secretName: terra-prometheus-cert
+      service:
+        annotations:
+          cloud.google.com/backend-config: '{"ports": {"9090": "prometheus-cloud-armor"}}'
+        type: NodePort
+      prometheusSpec:
+        externalUrl: https://prometheus.integ.envs.broadinstitute.org
+        containers:
+          - name: stackdriver-exporter
+            image: gcr.io/stackdriver-prometheus/stackdriver-prometheus-sidecar:0.7.5
+            imagePullPolicy: Always
+            args:
+              - --stackdriver.project-id=terra-kernel-k8s
+              - --prometheus.wal-directory=prometheus/wal
+              - --stackdriver.kubernetes.location=us-central1-a
+              - --stackdriver.kubernetes.cluster-name=terra-integration
+              #- \"--stackdriver.generic.location=us-central1\"
+              #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
+            ports:
+              - name: stackdriver-exp
+                containerPort: 9091
+            volumeMounts:
+              - name: prometheus-terra-prometheus-operator-prometheus-db
+                mountPath: /prometheus

--- a/terra/perf/values.yaml
+++ b/terra/perf/values.yaml
@@ -1,2 +1,54 @@
 terra-cluster-networking:
   enabled: false
+terra-prometheus:
+  # TLS Values
+  vaultCert:
+    enabled: true
+    cert:
+      path: secret/dsde/firecloud/perf/common/server.crt
+      secretKey: value
+    key:
+      path: secret/dsde/firecloud/perf/common/server.key
+      secretKey: value
+    chain:
+      path: secret/common/ca-bundle.crt
+      secretKey: chain
+  prometheus-operator:
+    fullnameOverride: "terra-prometheus-operator"
+    prometheusOperator:
+      createCustomResource: false
+    prometheus:
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.global-static-ip-name: terra-perf-prometheus-ip
+          kubernetes.io/ingress.allow-http: "false"
+        hosts:
+          - "prometheus.dsde-perf.broadinstitute.org"
+        paths:
+          - /*
+        tls:
+          - secretName: terra-prometheus-cert
+      service:
+        annotations:
+          cloud.google.com/backend-config: '{"ports": {"9090": "prometheus-cloud-armor"}}'
+        type: NodePort
+      prometheusSpec:
+        externalUrl: https://prometheus.dsde-perf.broadinstitute.org
+        containers:
+          - name: stackdriver-exporter
+            image: gcr.io/stackdriver-prometheus/stackdriver-prometheus-sidecar:0.7.5
+            imagePullPolicy: Always
+            args:
+              - --stackdriver.project-id=broad-dsde-perf
+              - --prometheus.wal-directory=prometheus/wal
+              - --stackdriver.kubernetes.location=us-central1-a
+              - --stackdriver.kubernetes.cluster-name=terra-perf
+              #- \"--stackdriver.generic.location=us-central1\"
+              #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
+            ports:
+              - name: stackdriver-exp
+                containerPort: 9091
+            volumeMounts:
+              - name: prometheus-terra-prometheus-operator-prometheus-db
+                mountPath: /prometheus

--- a/terra/staging/values.yaml
+++ b/terra/staging/values.yaml
@@ -1,2 +1,54 @@
 terra-cluster-networking:
   enabled: false
+terra-prometheus:
+  # TLS Values
+  vaultCert:
+    enabled: true
+    cert:
+      path: secret/dsde/firecloud/staging/common/server.crt
+      secretKey: value
+    key:
+      path: secret/dsde/firecloud/staging/common/server.key
+      secretKey: value
+    chain:
+      path: secret/common/ca-bundle.crt
+      secretKey: chain
+  prometheus-operator:
+    fullnameOverride: "terra-prometheus-operator"
+    prometheusOperator:
+      createCustomResource: false
+    prometheus:
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.global-static-ip-name: terra-staging-prometheus-ip
+          kubernetes.io/ingress.allow-http: "false"
+        hosts:
+          - "prometheus.dsde-staging.broadinstitute.org"
+        paths:
+          - /*
+        tls:
+          - secretName: terra-prometheus-cert
+      service:
+        annotations:
+          cloud.google.com/backend-config: '{"ports": {"9090": "prometheus-cloud-armor"}}'
+        type: NodePort
+      prometheusSpec:
+        externalUrl: https://prometheus.dsde-staging.broadinstitute.org
+        containers:
+          - name: stackdriver-exporter
+            image: gcr.io/stackdriver-prometheus/stackdriver-prometheus-sidecar:0.7.5
+            imagePullPolicy: Always
+            args:
+              - --stackdriver.project-id=broad-dsde-staging
+              - --prometheus.wal-directory=prometheus/wal
+              - --stackdriver.kubernetes.location=us-central1-a
+              - --stackdriver.kubernetes.cluster-name=terra-staging
+              #- \"--stackdriver.generic.location=us-central1\"
+              #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
+            ports:
+              - name: stackdriver-exp
+                containerPort: 9091
+            volumeMounts:
+              - name: prometheus-terra-prometheus-operator-prometheus-db
+                mountPath: /prometheus


### PR DESCRIPTION
Add environment specific values to be consumed by argocd for prometheus in all non-prod environments.