### PR TITLE
DDO-582 Add filter for k8s infra metrics

### DIFF
--- a/terra/dev/values.yaml
+++ b/terra/dev/values.yaml
@@ -44,6 +44,7 @@ terra-prometheus:
               - --stackdriver.kubernetes.cluster-name=terra-dev
               #- \"--stackdriver.generic.location=us-central1\"
               #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
+              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*",__name__=~".+"}
               - --include={__name__=~"kube_node_status_condition"} # Used for cluster health alert
             ports:
               - name: stackdriver-exp


### PR DESCRIPTION
This applies a filter for the label established in [this terra-helm pr](https://github.com/broadinstitute/terra-helm/pull/88/files).
It also filters for a few additional default prometheus metrics that we don't need to export to stackdriver that don't have a way to apply labels to them. 

I realize the filter query is ugly but it does achieve good performance when tested on the dev prometheus server.