### PR TITLE
Add stackdriver exporter filter for non prod envs

### DIFF
--- a/terra/alpha/values.yaml
+++ b/terra/alpha/values.yaml
@@ -46,6 +46,8 @@ terra-prometheus:
               - --stackdriver.kubernetes.cluster-name=terra-alpha
               #- \"--stackdriver.generic.location=us-central1\"
               #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
+              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*",__name__=~".+"}
+              - --include={__name__=~"kube_node_status_condition"} # Used for cluster health alert
             ports:
               - name: stackdriver-exp
                 containerPort: 9091

--- a/terra/dev/values.yaml
+++ b/terra/dev/values.yaml
@@ -44,7 +44,7 @@ terra-prometheus:
               - --stackdriver.kubernetes.cluster-name=terra-dev
               #- \"--stackdriver.generic.location=us-central1\"
               #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
-              - "--include={sd_export!=\"false\",__name__!~\"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*\",__name__=~\".+\"}"
+              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*",__name__=~".+"}
               - --include={__name__=~"kube_node_status_condition"} # Used for cluster health alert
 
             ports:

--- a/terra/integration/values.yaml
+++ b/terra/integration/values.yaml
@@ -38,6 +38,8 @@ terra-prometheus:
               - --stackdriver.kubernetes.cluster-name=terra-integration
               #- \"--stackdriver.generic.location=us-central1\"
               #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
+              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*",__name__=~".+"}
+              - --include={__name__=~"kube_node_status_condition"} # Used for cluster health alert
             ports:
               - name: stackdriver-exp
                 containerPort: 9091

--- a/terra/perf/values.yaml
+++ b/terra/perf/values.yaml
@@ -46,6 +46,8 @@ terra-prometheus:
               - --stackdriver.kubernetes.cluster-name=terra-perf
               #- \"--stackdriver.generic.location=us-central1\"
               #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
+              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*",__name__=~".+"}
+              - --include={__name__=~"kube_node_status_condition"} # Used for cluster health alert
             ports:
               - name: stackdriver-exp
                 containerPort: 9091

--- a/terra/staging/values.yaml
+++ b/terra/staging/values.yaml
@@ -46,6 +46,8 @@ terra-prometheus:
               - --stackdriver.kubernetes.cluster-name=terra-staging
               #- \"--stackdriver.generic.location=us-central1\"
               #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
+              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*",__name__=~".+"}
+              - --include={__name__=~"kube_node_status_condition"} # Used for cluster health alert
             ports:
               - name: stackdriver-exp
                 containerPort: 9091


### PR DESCRIPTION
This pr deploys the stackdriver exporter filter on prometheus to all envs