### PR TITLE
DDO-582 Ensure admission webhook is disabled in all clusters (known issue wit…

### DIFF
--- a/terra/alpha/values.yaml
+++ b/terra/alpha/values.yaml
@@ -17,6 +17,10 @@ terra-prometheus:
     fullnameOverride: "terra-prometheus-operator"
     prometheusOperator:
       createCustomResource: false
+      admissionWebhooks:
+        enabled: false # known issue with GKE clusters
+      tlsProxy:
+        enabled: false #
     prometheus:
       ingress:
         enabled: true

--- a/terra/dev/values.yaml
+++ b/terra/dev/values.yaml
@@ -15,6 +15,10 @@ terra-prometheus:
     fullnameOverride: "terra-prometheus-operator"
     prometheusOperator:
       createCustomResource: false
+      admissionWebhooks:
+        enabled: false # known issue with GKE clusters
+      tlsProxy:
+        enabled: false #
     prometheus:
       ingress:
         enabled: true

--- a/terra/integration/values.yaml
+++ b/terra/integration/values.yaml
@@ -9,6 +9,10 @@ terra-prometheus:
     fullnameOverride: "terra-prometheus-operator"
     prometheusOperator:
       createCustomResource: false
+      admissionWebhooks:
+        enabled: false # known issue with GKE clusters
+      tlsProxy:
+        enabled: false #
     prometheus:
       ingress:
         enabled: true

--- a/terra/perf/values.yaml
+++ b/terra/perf/values.yaml
@@ -17,6 +17,10 @@ terra-prometheus:
     fullnameOverride: "terra-prometheus-operator"
     prometheusOperator:
       createCustomResource: false
+      admissionWebhooks:
+        enabled: false # known issue with GKE clusters
+      tlsProxy:
+        enabled: false #
     prometheus:
       ingress:
         enabled: true

--- a/terra/staging/values.yaml
+++ b/terra/staging/values.yaml
@@ -17,6 +17,10 @@ terra-prometheus:
     fullnameOverride: "terra-prometheus-operator"
     prometheusOperator:
       createCustomResource: false
+      admissionWebhooks:
+        enabled: false # known issue with GKE clusters
+      tlsProxy:
+        enabled: false #
     prometheus:
       ingress:
         enabled: true


### PR DESCRIPTION
The admission webhook is getting reenabled somehow and it doesn not work with GKE. Trying to ensure it is disabled.