### PR TITLE
DDO-466 enable service monitor descovery in all namespaces

### DIFF
--- a/terra/dev/values.yaml
+++ b/terra/dev/values.yaml
@@ -66,6 +66,10 @@ terra-prometheus:
         type: NodePort
       prometheusSpec:
         externalUrl: https://prometheus.dsde-dev.broadinstitute.org
+        serviceMonitorSelectorNilUsesHelmValues: false
+        serviceMonitorSelector: {}
+        serviceMonitorNamespaceSelector:
+          any: true
         containers:
           - name: stackdriver-exporter
             image: gcr.io/stackdriver-prometheus/stackdriver-prometheus-sidecar:0.7.5


### PR DESCRIPTION
Enables prometheus to discover service monitor CRDs across all namespaces, not just the monitoring namespace where prometheus is installed.