### PR TITLE
DDO-629 Add support for pod and service discovery in all non prod prometheuses

### DIFF
--- a/terra/alpha/values.yaml
+++ b/terra/alpha/values.yaml
@@ -39,6 +39,12 @@ terra-prometheus:
         type: NodePort
       prometheusSpec:
         externalUrl: https://prometheus.dsde-alpha.broadinstitute.org
+        serviceMonitorSelectorNilUsesHelmValues: false
+        serviceMonitorSelector: {}
+        serviceMonitorNamespaceSelector: {}
+        podMonitorSelectorNilUsesHelmValues: false
+        podMonitorSelector: {}
+        podMonitorNamespaceSelector: {}
         containers:
           - name: stackdriver-exporter
             image: gcr.io/stackdriver-prometheus/stackdriver-prometheus-sidecar:0.7.5

--- a/terra/integration/values.yaml
+++ b/terra/integration/values.yaml
@@ -31,6 +31,12 @@ terra-prometheus:
         type: NodePort
       prometheusSpec:
         externalUrl: https://prometheus.integ.envs.broadinstitute.org
+        serviceMonitorSelectorNilUsesHelmValues: false
+        serviceMonitorSelector: {}
+        serviceMonitorNamespaceSelector: {}
+        podMonitorSelectorNilUsesHelmValues: false
+        podMonitorSelector: {}
+        podMonitorNamespaceSelector: {}
         containers:
           - name: stackdriver-exporter
             image: gcr.io/stackdriver-prometheus/stackdriver-prometheus-sidecar:0.7.5

--- a/terra/perf/values.yaml
+++ b/terra/perf/values.yaml
@@ -39,6 +39,12 @@ terra-prometheus:
         type: NodePort
       prometheusSpec:
         externalUrl: https://prometheus.dsde-perf.broadinstitute.org
+        serviceMonitorSelectorNilUsesHelmValues: false
+        serviceMonitorSelector: {}
+        serviceMonitorNamespaceSelector: {}
+        podMonitorSelectorNilUsesHelmValues: false
+        podMonitorSelector: {}
+        podMonitorNamespaceSelector: {}
         containers:
           - name: stackdriver-exporter
             image: gcr.io/stackdriver-prometheus/stackdriver-prometheus-sidecar:0.7.5

--- a/terra/staging/values.yaml
+++ b/terra/staging/values.yaml
@@ -39,6 +39,12 @@ terra-prometheus:
         type: NodePort
       prometheusSpec:
         externalUrl: https://prometheus.dsde-staging.broadinstitute.org
+        serviceMonitorSelectorNilUsesHelmValues: false
+        serviceMonitorSelector: {}
+        serviceMonitorNamespaceSelector: {}
+        podMonitorSelectorNilUsesHelmValues: false
+        podMonitorSelector: {}
+        podMonitorNamespaceSelector: {}
         containers:
           - name: stackdriver-exporter
             image: gcr.io/stackdriver-prometheus/stackdriver-prometheus-sidecar:0.7.5


### PR DESCRIPTION
This pr enables automatic podMonitor and ServiceMonitor discovery in all namespaces for all non prod prometheus. 

Prod prometheus will be updated separately after confirming all is well.