### PR TITLE
DDO-700 Deploy prometheus instance to prod.

### DIFF
--- a/terra/prod/values.yaml
+++ b/terra/prod/values.yaml
@@ -1,2 +1,64 @@
 terra-cluster-networking:
   enabled: false
+terra-prometheus:
+  # TLS Values
+  vaultCert:
+    enabled: true
+    cert:
+      path: secret/dsde/firecloud/prod/common/server.crt
+      secretKey: value
+    key:
+      path: secret/dsde/firecloud/prod/common/server.key
+      secretKey: value
+    chain:
+      path: secret/common/ca-bundle.crt
+      secretKey: chain
+  prometheus-operator:
+    fullnameOverride: "terra-prometheus-operator"
+    prometheusOperator:
+      createCustomResource: false
+      admissionWebhooks:
+        enabled: false # known issue with GKE clusters
+      tlsProxy:
+        enabled: false #
+    prometheus:
+      ingress:
+        enabled: false
+        annotations:
+          kubernetes.io/ingress.global-static-ip-name: terra-prod-prometheus-ip
+          kubernetes.io/ingress.allow-http: "false"
+        hosts:
+          - "prometheus.dsde-prod.broadinstitute.org"
+        paths:
+          - /*
+        tls:
+          - secretName: terra-prometheus-cert
+      service:
+        annotations:
+          cloud.google.com/backend-config: '{"ports": {"9090": "prometheus-cloud-armor"}}'
+        type: NodePort
+      prometheusSpec:
+        externalUrl: https://prometheus.dsde-prod.broadinstitute.org
+        serviceMonitorSelectorNilUsesHelmValues: false
+        serviceMonitorSelector: {}
+        serviceMonitorNamespaceSelector: {}
+        podMonitorSelectorNilUsesHelmValues: false
+        podMonitorSelector: {}
+        podMonitorNamespaceSelector: {}
+        containers:
+          - name: stackdriver-exporter
+            image: gcr.io/stackdriver-prometheus/stackdriver-prometheus-sidecar:0.7.5
+            imagePullPolicy: Always
+            args:
+              - --stackdriver.project-id=broad-dsde-prod
+              - --prometheus.wal-directory=prometheus/wal
+              - --stackdriver.kubernetes.location=us-central1-a
+              - --stackdriver.kubernetes.cluster-name=terra-prod
+              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*",__name__=~".+"}
+              - --include={__name__=~"kube_node_status_condition"} # Used for cluster health alert
+            ports:
+              - name: stackdriver-exp
+                containerPort: 9091
+            volumeMounts:
+              - name: prometheus-terra-prometheus-operator-prometheus-db
+                mountPath: /prometheus


### PR DESCRIPTION
This pr coupled with a manual chart version bump in argoCD will deploy a prometheus instance to the terra-prod cluster. The only way to access metric data from this prometheus deployment is via stackdriver. Access is gated in the same manner as access to the broad-dsde-prod google project. 

All ingresses to the prometheus server are disabled until we have an approved solution for Oauth.