### PR TITLE
Disable alertmanager in dev

### DIFF
--- a/terra/dev/values.yaml
+++ b/terra/dev/values.yaml
@@ -14,6 +14,7 @@ terra-prometheus:
   prometheus-operator:
     fullnameOverride: "terra-prometheus-operator"
     alertmanager:
+      enabled: false
       alertmanagerSpec:
         configSecret: terra-prometheus-alertmanager-config
     # disable bad scrape target


### PR DESCRIPTION
The dev env is causing alot of noise in alertmanager. 
THe alerts are difficult to tune until prometheus is stripped
out of the terra cluster umbrella chart and managed via its own deployment
disable for now to reduce noise﻿
