### PR TITLE
DDO-910 Deploy filebeat in all clusters

### DIFF
--- a/filebeat/alpha/values.yaml
+++ b/filebeat/alpha/values.yaml
@@ -1,0 +1,4 @@
+vault:
+  logitUrlPath: secret/dsde/firecloud/alpha/common/logitapi
+beatsPort: "18461" 
+environmentName: alpha

--- a/filebeat/perf/values.yaml
+++ b/filebeat/perf/values.yaml
@@ -1,0 +1,4 @@
+vault:
+  logitUrlPath: secret/dsde/firecloud/perf/common/logitapi
+beatsPort: "18461" 
+environmentName: perf

--- a/filebeat/prod/values.yaml
+++ b/filebeat/prod/values.yaml
@@ -1,0 +1,4 @@
+vault:
+  logitUrlPath: secret/dsde/firecloud/prod/common/logitapi
+beatsPort: "20000" 
+environmentName: prod

--- a/filebeat/staging/values.yaml
+++ b/filebeat/staging/values.yaml
@@ -1,0 +1,4 @@
+vault:
+  logitUrlPath: secret/dsde/firecloud/staging/common/logitapi
+beatsPort: "18461" 
+environmentName: staging

--- a/terra/dev/values.yaml
+++ b/terra/dev/values.yaml
@@ -14,6 +14,7 @@ terra-prometheus:
   prometheus-operator:
     fullnameOverride: "terra-prometheus-operator"
     alertmanager:
+      enabled: false
       alertmanagerSpec:
         configSecret: terra-prometheus-alertmanager-config
     # disable bad scrape target


### PR DESCRIPTION
Enable shipping gke application logs to kibana for data warehouse consumption.

﻿- create values files for all clusters
- update alpha
- add staging
- disable alert manager in dev
- add prod values
