### PR TITLE
[DDO-1276] Atlantis provider cache cleanup

### DIFF
--- a/dsp-tools/dsp-atlantis/values.yaml
+++ b/dsp-tools/dsp-atlantis/values.yaml
@@ -36,7 +36,6 @@ atlantis:
     limits:
       memory: 3Gi
       cpu: "3"
-  dataStorage: 10Gi
   environment:
     ATLANTIS_HIDE_PREV_PLAN_COMMENTS: true
   environmentSecrets:

--- a/dsp-tools/dsp-atlantis/values.yaml
+++ b/dsp-tools/dsp-atlantis/values.yaml
@@ -80,3 +80,11 @@ atlantis:
       workflow: default
       allowed_overrides: [workflow]
       allow_custom_workflows: true
+
+cleanup:
+  enabled: true
+
+vaultSecrets:
+  cleanupCredentials:
+    path: secret/devops/terraform/atlantis/atlantis-pod-cleanup-sa.json
+    key: sa-key.json.b64

--- a/dsp-tools/dsp-atlantis/values.yaml
+++ b/dsp-tools/dsp-atlantis/values.yaml
@@ -36,6 +36,7 @@ atlantis:
     limits:
       memory: 3Gi
       cpu: "3"
+  dataStorage: 10Gi
   environment:
     ATLANTIS_HIDE_PREV_PLAN_COMMENTS: true
   environmentSecrets:

--- a/dsp-tools/dsp-atlantis/values.yaml
+++ b/dsp-tools/dsp-atlantis/values.yaml
@@ -6,6 +6,9 @@ azure:
 vault:
   azure:
     pathPrefix: secret/devops/terraform/azure
+  cleanup:
+    path: secret/devops/terraform/atlantis/atlantis-pod-cleanup-sa.json
+    key: sa-key.json.b64
 atlantis:
   defaultTFVersion: '0.12.21'
   atlantisUrl: https://atlantis.dsp-devops.broadinstitute.org
@@ -83,8 +86,3 @@ atlantis:
 
 cleanup:
   enabled: true
-
-vaultSecrets:
-  cleanupCredentials:
-    path: secret/devops/terraform/atlantis/atlantis-pod-cleanup-sa.json
-    key: sa-key.json.b64


### PR DESCRIPTION
Enables cleanup and provides the Vault info for the GCP SA that cleanup requires

Related to / dependent on https://github.com/broadinstitute/terra-helm/pull/382