### PR TITLE
[No Ticket] Disabling kibana forwarding for select services in dev

### DIFF
--- a/filebeat/dev/values.yaml
+++ b/filebeat/dev/values.yaml
@@ -3,7 +3,7 @@ vault:
 beatsPort: "18461" 
 environmentName: dev
 ignore:
-  - workspace-manager
+  - workspacemanager
   - buffer
   - leonardo
   - sam

--- a/filebeat/dev/values.yaml
+++ b/filebeat/dev/values.yaml
@@ -2,3 +2,11 @@ vault:
   logitUrlPath: secret/dsde/firecloud/dev/common/logitapi
 beatsPort: "18461" 
 environmentName: dev
+ignore:
+  - workspace-manager
+  - buffer
+  - leonardo
+  - sam
+  - cromwell
+  - consent
+  - ontology


### PR DESCRIPTION
To support beginning to phase out kibana. We are ignoring a subset of services in dev so that their logs are no longer sent to kibana. Previously, ignoring workspacemanager and buffer was hardcoded into the helm chart. Now it is passed via values here for transparency.