### PR TITLE
DDO-1304 re-added TF_VARS_github_token for saturn legacy requirements,

### DIFF
--- a/dsp-tools/dsp-atlantis/values.yaml
+++ b/dsp-tools/dsp-atlantis/values.yaml
@@ -59,6 +59,11 @@ atlantis:
       secretKeyRef:
         name: atlantis-vault-approle
         key: secret-id
+    # legacy github account oauth token used by saturn
+    - name: TF_VAR_github_token
+      secretKeyRef:
+        name: atlantis-github-provider
+        key: github-token
     # dsp-atlantis github account oauth token
     - name: TF_VAR_dsp_atlantis_github_token
       secretKeyRef:


### PR DESCRIPTION
changing the key made atlantis want to redeploy which exploded due to different perms.