### PR TITLE
[DDO-1424] copy dsp-ci values, add sysbox ones

### DIFF
--- a/dsp-ci/dsp-gha-runner-controller/values.yaml
+++ b/dsp-ci/dsp-gha-runner-controller/values.yaml
@@ -1,0 +1,4 @@
+vault:
+  github:
+    tokenSecret:
+      path: secret/suitable/github/broad-runner-bot/tokens/hosted-actions-runner-registration

--- a/dsp-ci/dsp-gha-runner-instances/values.yaml
+++ b/dsp-ci/dsp-gha-runner-instances/values.yaml
@@ -1,0 +1,3 @@
+runners:
+  - name: revere
+    repository: broadinstitute/revere


### PR DESCRIPTION
Make a new dsp-ci directory for these things, I'll delete the old copies once Argo knows about the new location.

Adds an empty stub file for sysbox's chart.