### PR TITLE
DDO-1430 Reduce ingest of unecessary metrics into google monitoring

### DIFF
--- a/terra/alpha/values.yaml
+++ b/terra/alpha/values.yaml
@@ -73,7 +73,7 @@ terra-prometheus:
               - --stackdriver.kubernetes.cluster-name=terra-alpha
               #- \"--stackdriver.generic.location=us-central1\"
               #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
-              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*",__name__=~".+"}
+              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*|metrics_.*|java_lang.*|machine_.*|namespace_.*",__name__=~".+"}
               - --include={__name__=~"kube_node_status_condition"} # Used for cluster health alert
             ports:
               - name: stackdriver-exp

--- a/terra/dev/values.yaml
+++ b/terra/dev/values.yaml
@@ -94,7 +94,7 @@ terra-prometheus:
               - --stackdriver.kubernetes.cluster-name=terra-dev
               #- \"--stackdriver.generic.location=us-central1\"
               #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
-              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*",__name__=~".+"}
+              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*|metrics_.*|java_lang.*",__name__=~".+"}
               - --include={__name__=~"kube_node_status_condition"} # Used for cluster health alert
             ports:
               - name: stackdriver-exp

--- a/terra/dev/values.yaml
+++ b/terra/dev/values.yaml
@@ -94,7 +94,7 @@ terra-prometheus:
               - --stackdriver.kubernetes.cluster-name=terra-dev
               #- \"--stackdriver.generic.location=us-central1\"
               #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
-              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*|metrics_.*|java_lang.*",__name__=~".+"}
+              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*|metrics_.*|java_lang.*|machine_.*|namespace_.*",__name__=~".+"}
               - --include={__name__=~"kube_node_status_condition"} # Used for cluster health alert
             ports:
               - name: stackdriver-exp

--- a/terra/integration/values.yaml
+++ b/terra/integration/values.yaml
@@ -62,7 +62,7 @@ terra-prometheus:
               - --stackdriver.kubernetes.cluster-name=terra-integration
               #- \"--stackdriver.generic.location=us-central1\"
               #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
-              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*",__name__=~".+"}
+              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*|metrics_.*|java_lang.*|machine_.*|namespace_.*",__name__=~".+"}
               - --include={__name__=~"kube_node_status_condition"} # Used for cluster health alert
             ports:
               - name: stackdriver-exp

--- a/terra/perf/values.yaml
+++ b/terra/perf/values.yaml
@@ -73,7 +73,7 @@ terra-prometheus:
               - --stackdriver.kubernetes.cluster-name=terra-perf
               #- \"--stackdriver.generic.location=us-central1\"
               #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
-              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*",__name__=~".+"}
+              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*|metrics_.*|java_lang.*|machine_.*|namespace_.*",__name__=~".+"}
               - --include={__name__=~"kube_node_status_condition"} # Used for cluster health alert
             ports:
               - name: stackdriver-exp

--- a/terra/prod/values.yaml
+++ b/terra/prod/values.yaml
@@ -71,7 +71,7 @@ terra-prometheus:
               - --prometheus.wal-directory=prometheus/wal
               - --stackdriver.kubernetes.location=us-central1-a
               - --stackdriver.kubernetes.cluster-name=terra-prod
-              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*",__name__=~".+"}
+              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*|metrics_.*|java_lang.*|machine_.*|namespace_.*",__name__=~".+"}
               - --include={__name__=~"kube_node_status_condition"} # Used for cluster health alert
             ports:
               - name: stackdriver-exp

--- a/terra/staging/values.yaml
+++ b/terra/staging/values.yaml
@@ -73,7 +73,7 @@ terra-prometheus:
               - --stackdriver.kubernetes.cluster-name=terra-staging
               #- \"--stackdriver.generic.location=us-central1\"
               #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
-              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*",__name__=~".+"}
+              - --include={sd_export!="false",__name__!~"container_.*|scrape_.*|node_.*|prober_.*|instance:.*|code_.*|mixin_.*|cluster_.*|metrics_.*|java_lang.*|machine_.*|namespace_.*",__name__=~".+"}
               - --include={__name__=~"kube_node_status_condition"} # Used for cluster health alert
             ports:
               - name: stackdriver-exp


### PR DESCRIPTION
This is a quick hack fix to stop sending a bunch of unnecessary prometheus metrics to google monitoring. A better long term fix is to update the `prometheusJMX` config in consent and ontology's helm charts. This is a quick fix to try and get the ingest spend down.