### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+<!-- 
+Please add links to any related PRs--thanks!
+-->


### PR DESCRIPTION
As discussed in retro, an idea for a very minimal PR template to promote linking to related PRs. More info in #ap-devops.