### PR TITLE
[DDO-1545] Remove sysbox values file

### DIFF
--- a/dsp-ci/dsp-gha-runner-instances/values.yaml
+++ b/dsp-ci/dsp-gha-runner-instances/values.yaml
@@ -1,3 +1,8 @@
+runnerDefaults:
+  spec:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: ci-runners-v1
+
 runners:
   - name: revere
     repository: broadinstitute/revere


### PR DESCRIPTION
<!-- 
Please add links to any related PRs--thanks!
-->
Remove what will be an unused stub values file, and force the runners to use the ci-runners node pool made per https://github.com/broadinstitute/terraform-ap-deployments/pull/427

**Merge order**: last for DDO-1545 (after https://github.com/broadinstitute/terraform-ap-deployments/pull/427)

**Post-merge**: update [the design document](https://docs.google.com/document/d/14CSID7YW5LrCxcuNHpHgv4vc8lDOIZW7_UL2rgx2YSI/edit#heading=h.kd1qu8sjxuwp) to reflect the current state of everything