### PR TITLE
[DDO-1545] Use sidecar for docker

### DIFF
--- a/dsp-ci/dsp-gha-runner-instances/values.yaml
+++ b/dsp-ci/dsp-gha-runner-instances/values.yaml
@@ -1,6 +1,7 @@
+defaultDockerConfig: privilegedSidecar
+
 runnerDefaults:
   spec:
-    image: summerwind/actions-runner-dind:latest
     nodeSelector:
       cloud.google.com/gke-nodepool: ci-runners-v1
 

--- a/dsp-ci/dsp-gha-runner-instances/values.yaml
+++ b/dsp-ci/dsp-gha-runner-instances/values.yaml
@@ -1,5 +1,6 @@
 runnerDefaults:
   spec:
+    image: summerwind/actions-runner-dind:latest
     nodeSelector:
       cloud.google.com/gke-nodepool: ci-runners-v1
 


### PR DESCRIPTION
<!-- 
Please add links to any related PRs--thanks!
-->
I just plainly messed up on Friday and used the configuration that makes the actions container privileged, instead of the one that splits out Docker and just makes Docker privileged.

Benefit of me making this toggleable, I guess. This change does the whole switch across everywhere. This is already deployed, it worked in my testing, Dan thinks it is working too but will hold off on merging until I confirm.