### PR TITLE
added new runner for firecloud-automated-testing

### DIFF
--- a/dsp-ci/dsp-gha-runner-instances/values.yaml
+++ b/dsp-ci/dsp-gha-runner-instances/values.yaml
@@ -45,3 +45,6 @@ runners:
           limits:
             cpu: "2"
             memory: "8Gi"
+  - name: firecloud-automated-testing
+    repository: broadinstitute/firecloud-automated-testing
+    


### PR DESCRIPTION
for firecloud-automated-testing so GHA can hit fiabs and fiab-like resources.
